### PR TITLE
Support authorized_user ADC credentials

### DIFF
--- a/libs/gcp.py
+++ b/libs/gcp.py
@@ -31,21 +31,31 @@ class GCP:
                 )
                 sys.exit("Exiting...")
 
-            required_keys = ["project_id", "client_email", "private_key"]
-            missing_keys = [key for key in required_keys if key not in self.gcp_credentials]
-            if missing_keys:
-                self.logging.error(
-                    f"Missing required credentials in file {self.credentials_file}: "
-                    f"{', '.join(missing_keys)}"
+            self.credential_type = self.gcp_credentials.get("type", "service_account")
+
+            if self.credential_type == "authorized_user":
+                self.logging.info(
+                    f"Detected authorized_user credentials in {self.credentials_file}; "
+                    "project_id and region must be supplied via CLI arguments"
                 )
-                sys.exit("Exiting...")
+            else:
+                required_keys = ["project_id", "client_email", "private_key"]
+                missing_keys = [key for key in required_keys if key not in self.gcp_credentials]
+                if missing_keys:
+                    self.logging.error(
+                        f"Missing required credentials in file {self.credentials_file}: "
+                        f"{', '.join(missing_keys)}"
+                    )
+                    sys.exit("Exiting...")
 
             self.logging.info(f"GCP configuration verified for file {self.credentials_file}")
             self.logging.debug(
-                f"GCP Credentials: project_id={self.gcp_credentials.get('project_id', 'N/A')}, "
+                f"GCP Credentials: type={self.credential_type}, "
+                f"project_id={self.gcp_credentials.get('project_id', 'N/A')}, "
                 f"client_email={self.gcp_credentials.get('client_email', 'N/A')}"
             )
         else:
+            self.credential_type = None
             self.logging.info(
                 "GCP credentials file is not provided or not found; "
                 "GOOGLE_APPLICATION_CREDENTIALS / ADC environment variables are being used"
@@ -67,10 +77,16 @@ class GCP:
                     f"Credentials file project_id ({self.gcp_credentials['project_id']}) differs "
                     f"from --gcp-project-id ({project_id}); using --gcp-project-id for API calls"
                 )
-            self.logging.info(
-                f"ADC identity: {self.gcp_credentials.get('client_email')} "
-                f"(GOOGLE_APPLICATION_CREDENTIALS + GOOGLE_CLOUD_PROJECT={project_id})"
-            )
+            if self.credential_type == "authorized_user":
+                self.logging.info(
+                    f"ADC identity: authorized_user "
+                    f"(GOOGLE_APPLICATION_CREDENTIALS + GOOGLE_CLOUD_PROJECT={project_id})"
+                )
+            else:
+                self.logging.info(
+                    f"ADC identity: {self.gcp_credentials.get('client_email')} "
+                    f"(GOOGLE_APPLICATION_CREDENTIALS + GOOGLE_CLOUD_PROJECT={project_id})"
+                )
 
     def set_gcp_environment(self, project_id, gcp_region):
         """Return GCP info dict for the platform environment object."""
@@ -79,6 +95,7 @@ class GCP:
             "region": gcp_region,
             "credentials_file": self.credentials_file,
         }
+        gcp["credential_type"] = self.credential_type
         if self.credentials_file and os.path.exists(self.credentials_file):
             gcp["client_email"] = self.gcp_credentials.get("client_email", "")
             gcp["credentials_project_id"] = self.gcp_credentials.get("project_id", "")

--- a/libs/platforms/gcp/gcp.py
+++ b/libs/platforms/gcp/gcp.py
@@ -29,13 +29,20 @@ class Gcp(Platform):
         creds_file = self.environment["gcp_credentials_file"]
         client_email = self.environment["gcp"].get("client_email", "")
 
-        self.logging.info("Authenticating with GCP using service account")
-        auth_code, _, _ = self.utils.subprocess_exec(
-            f"gcloud auth activate-service-account {client_email} --key-file={creds_file}"
-        )
-        if auth_code != 0:
-            self.logging.error("Failed to authenticate with GCP")
-            sys.exit("Exiting...")
+        credential_type = self.environment["gcp"].get("credential_type")
+        if credential_type == "authorized_user":
+            self.logging.info(
+                "Using authorized_user ADC credentials; skipping gcloud auth "
+                "(user is already authenticated via 'gcloud auth application-default login')"
+            )
+        else:
+            self.logging.info("Authenticating with GCP using service account")
+            auth_code, _, _ = self.utils.subprocess_exec(
+                f"gcloud auth activate-service-account {client_email} --key-file={creds_file}"
+            )
+            if auth_code != 0:
+                self.logging.error("Failed to authenticate with GCP")
+                sys.exit("Exiting...")
 
         set_code, _, _ = self.utils.subprocess_exec(
             f"gcloud config set project {project_id}"


### PR DESCRIPTION
## Summary
- Detect `"type": "authorized_user"` in the credentials JSON and skip SA-only field validation (`project_id`, `client_email`, `private_key`)
- Skip `gcloud auth activate-service-account` for user ADC since the user is already authenticated via `gcloud auth application-default login`
- `GOOGLE_APPLICATION_CREDENTIALS` + `--gcp-project-id` are sufficient for user ADC to work

## Test plan
- [ ] Run with a service account key file — should work as before
- [ ] Run with `~/.config/gcloud/application_default_credentials.json` + `--gcp-project-id` — should authenticate without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)